### PR TITLE
Quick fix, change link to new validator

### DIFF
--- a/index.php
+++ b/index.php
@@ -194,7 +194,7 @@ if (!isset($_REQUEST["showblank"])) {
                     echo $day;
                     echo date("H:i:s",filemtime( "/tmp/" . nice_file_name($newurl) )) . "</div>";
 
-                    echo '<a href="http://validator.iatistandard.org/?url=' . safeurl($newurl) . '" target="_blank">Check this data in the IATI Public Validator</a> [opens in new window]';
+                    echo '<a href="https://iativalidator.iatistandard.org/organisations" target="_blank">Check this data in the IATI Validator</a> [opens in new window]';
 
                     echo '</div>';
 


### PR DESCRIPTION
A user found a link to the old validator on this page. Seems a temporary fix to point them to the new one whilst waiting for previewer deprecation.